### PR TITLE
fix: chevrondown for github button didn't match the text size

### DIFF
--- a/lib/components/Header/components/GithubDropdownMenu.tsx
+++ b/lib/components/Header/components/GithubDropdownMenu.tsx
@@ -12,7 +12,7 @@ export const GithubDropdownMenu = ({ ghRepoName }: { ghRepoName: string }) => {
         <DropdownMenuTrigger asChild>
           <Button variant="outlineBrand" forcedColorScheme="dark" className={"mr-4 px-3 h-[32px]"}>
             Github&nbsp;
-            <ChevronDown height={20} />
+            <ChevronDown className="ml-2 h-5 w-4" />
           </Button>
         </DropdownMenuTrigger>
       )}


### PR DESCRIPTION
before:
<img width="426" height="57" alt="Screenshot 2025-08-19 at 13 47 45" src="https://github.com/user-attachments/assets/2021b5ec-20a8-4b3f-a661-e13372ed79b2" />


after:
<img width="402" height="67" alt="Screenshot 2025-08-19 at 13 47 04" src="https://github.com/user-attachments/assets/8bb5e870-11c9-4935-9c94-29d683c3ff24" />
